### PR TITLE
hint to avoid duplicate/overwrite of variables

### DIFF
--- a/advanced-information-retrieval/neural-ir-exercise/src/train.py
+++ b/advanced-information-retrieval/neural-ir-exercise/src/train.py
@@ -71,7 +71,8 @@ for epoch in range(2):
 
 
 #
-# eval (duplicate for validation inside train loop)
+# eval (duplicate for validation inside train loop - but rename "_iterator", since
+# otherwise it will overwrite the original train iterator, which is instantiated outside the loop)
 #
 
 _tuple_loader = IrLabeledTupleDatasetReader(lazy=True, max_doc_length=180, max_query_length=30) # not spacy tokenized already (default is spacy)


### PR DESCRIPTION
If the people really just duplicate/copy this fragment _iterator will overwrite the previous train _iterator and raise an Exception at Epoch 2..

Quite minimalistic Exception "KeyError: 'doc_tokens'" which is caused bye trying to sort the non existing key "doc_tokens"