### PR TITLE
Fixed bug where shape of np.zeros array wasn't defined correctly

### DIFF
--- a/advanced-information-retrieval/neural-ir-exercise-2022/src/core_metrics.py
+++ b/advanced-information-retrieval/neural-ir-exercise-2022/src/core_metrics.py
@@ -29,10 +29,10 @@ def calculate_metrics_plain(ranking, qrels, binarization_point=1.0, return_per_q
 
     ranked_queries = len(ranking)
     ap_per_candidate_depth = np.zeros(ranked_queries)
-    rr_per_candidate_depth = np.zeros(len(global_metric_config["MRR+Recall@"]), ranked_queries)
-    rank_per_candidate_depth = np.zeros(len(global_metric_config["MRR+Recall@"]), ranked_queries)
-    recall_per_candidate_depth = np.zeros(len(global_metric_config["MRR+Recall@"]), ranked_queries)
-    ndcg_per_candidate_depth = np.zeros(len(global_metric_config["nDCG@"]), ranked_queries)
+    rr_per_candidate_depth = np.zeros((len(global_metric_config["MRR+Recall@"]), ranked_queries))
+    rank_per_candidate_depth = np.zeros((len(global_metric_config["MRR+Recall@"]), ranked_queries))
+    recall_per_candidate_depth = np.zeros((len(global_metric_config["MRR+Recall@"]), ranked_queries))
+    ndcg_per_candidate_depth = np.zeros((len(global_metric_config["nDCG@"]), ranked_queries))
     evaluated_queries = 0
 
     for query_index, (query_id, ranked_doc_ids) in enumerate(ranking.items()):


### PR DESCRIPTION
In the current version, the argument "ranked_queries" is passed as an additional argument instead of being part of the shape, meaning that numpy interprets it as a datatype.